### PR TITLE
Improving SolveUnc.tsolve() for very large force matrices

### DIFF
--- a/pyyeti/ode/solveunc.py
+++ b/pyyeti/ode/solveunc.py
@@ -859,17 +859,17 @@ class SolveUnc(_BaseODE):
         Bp = pc.Bp
         D = d[kdof]
         V = v[kdof]
-        if self.order == 1:
-            ABF = A[:, None] * force[kdof, :-1] + B[:, None] * force[kdof, 1:]
-            ABFp = Ap[:, None] * force[kdof, :-1] + Bp[:, None] * force[kdof, 1:]
-        else:
-            ABF = (A + B)[:, None] * force[kdof, :-1]
-            ABFp = (Ap + Bp)[:, None] * force[kdof, :-1]
         di = D[:, 0]
         vi = V[:, 0]
         for i in range(nt - 1):
-            din = F * di + G * vi + ABF[:, i]
-            vi = V[:, i + 1] = Fp * di + Gp * vi + ABFp[:, i]
+            if self.order == 1:
+                ABFi = A * force[kdof, :-1][:, i] + B * force[kdof, 1:][:, i]
+                ABFpi = Ap * force[kdof, :-1][:, i] + Bp * force[kdof, 1:][:, i]
+            else:
+                ABFi = (A + B) * force[kdof, :-1][:, i]
+                ABFpi = (Ap + Bp) * force[kdof, :-1][:, i]
+            din = F * di + G * vi + ABFi
+            vi = V[:, i + 1] = Fp * di + Gp * vi + ABFpi
             D[:, i + 1] = di = din
         if not self.slices:
             d[kdof] = D


### PR DESCRIPTION
This change to SolveUnc.tsolve() in _solve_real_unc() prevents memory allocation for large (force ~ [4,000 modes x 110,000 time steps]) ABF and ABFp matrices, saving time and memory during uncoupled solve. Seeing reduction of tsolve() time from 20 seconds to ~13 seconds in this case. I did my best to see that tests still passed on my machine, and I believe they did. However, I'm not used to nosetests so I could be wrong.

I initially was looking to see if Numba could be used to boost tsolve() performance on large models/solves, so I also have a working (but messy) copy of that if you would like to see it, Tim.