### PR TITLE
Add PEP-517/518 Compliance to PyYeti

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools", "distutils", "numpy"]
+build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools", "distutils", "numpy"]
+requires = ["setuptools","numpy"]
 build-backend = "setuptools.build_meta"

--- a/pyyeti/__init__.py
+++ b/pyyeti/__init__.py
@@ -26,5 +26,6 @@ pyYeti has tools mostly related to structural dynamics:
     * Other miscellaneous tools
 
 """
+from importlib.metadata import version
 
-__version__ = "1.1.8"
+__version__ = version()

--- a/pyyeti/__init__.py
+++ b/pyyeti/__init__.py
@@ -28,4 +28,4 @@ pyYeti has tools mostly related to structural dynamics:
 """
 from importlib.metadata import version
 
-__version__ = version()
+__version__ = version("pyyeti")

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ def run_setup(with_binary):
     install_requires = check_dependencies()
     setup(
         name="pyyeti",
-        version="1.1.18",
+        version="1.1.8",
         url="http://github.com/twmacro/pyyeti/",
         license="BSD",
         author="Tim Widrick",

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ from setuptools import setup, find_packages, Extension
 from distutils.command.build_ext import build_ext
 from distutils.errors import CCompilerError, DistutilsExecError, DistutilsPlatformError
 import numpy
-import pyyeti
 import os
 
 
@@ -97,7 +96,7 @@ def run_setup(with_binary):
     install_requires = check_dependencies()
     setup(
         name="pyyeti",
-        version=pyyeti.__version__,
+        version="1.1.18",
         url="http://github.com/twmacro/pyyeti/",
         license="BSD",
         author="Tim Widrick",


### PR DESCRIPTION
This pull request adds compliance to [PEP-517](https://peps.python.org/pep-0517/) and [PEP-518](https://peps.python.org/pep-0518/), which will allow it to be built in an isolated environment. This came to my attention with the release of [poetry 1.2.0](https://github.com/python-poetry/poetry) this week which now insists on PEP-517 being followed.

**Changes summary:**
- Add `pyproject.toml`
- Remove pyyeti as requirement from `setup.py`
- Replace `pyyeti.__version__` with the hard-coded value in `setup.py`
  - Retrieve this value at runtime via the method [recommended by setuptools](https://setuptools.pypa.io/en/latest/pkg_resources.html#package-discovery-and-resource-access-using-pkg-resources) in `__init__.py`

**Future work:**
- Investigate whether building with `c_rain` is broken by this
  - I do not have any c compilers on my windows distribution, so it's hard to troubleshoot this issue at the moment. Ultimately I decided it was more important to be able to build w/ numba and fix that later than be unable to build in isolated environments. 