### PR TITLE
Swapped signs for shifting geometry based on the new CS origin

### DIFF
--- a/pyyeti/nastran/n2p.py
+++ b/pyyeti/nastran/n2p.py
@@ -2344,7 +2344,7 @@ def getcoordinates(uset, gid, csys, coordref=None):
         else: #is coord
             xyz_basic = np.asarray(igid).ravel()
         if np.size(csys) == 1 and csys == 0:
-            return xyz_basic
+            result.append(xyz_basic)
         # get input "coordinfo" [ cid type 0; location(1x3); T(3x3) ]:
         if coordref is None:
             coordref = {}

--- a/pyyeti/nastran/n2p.py
+++ b/pyyeti/nastran/n2p.py
@@ -2327,13 +2327,16 @@ def getcoordinates(uset, gid, csys, coordref=None):
     >>> nastran.getcoordinates(uset, 200, 2) - np.array([r, th, phi])
     array([ 0.,  0.,  0.])
     """
+    if len(np.shape(gid)) == 0:  # user passed in a single number
+        gid = [gid]
     n_locations = np.shape(gid)[0]
-    if len(np.shape(gid)) == 1:
+    if len(np.shape(gid)) == 1:  # user passed in a 1-d array
         isgrid = True
-    elif np.shape(gid)[1] == 3:
+    elif np.shape(gid)[1] == 3:  # user passed in a 2-d array w/ 3 col
         isgrid = False
-    else:
+    else: # user passed in a 2-d array w/ non-3 col
         isgrid = True
+        gid = np.array(gid).flatten() 
     result = []
     for igid in gid:
         if isgrid:

--- a/pyyeti/nastran/n2p.py
+++ b/pyyeti/nastran/n2p.py
@@ -2345,30 +2345,31 @@ def getcoordinates(uset, gid, csys, coordref=None):
             xyz_basic = np.asarray(igid).ravel()
         if np.size(csys) == 1 and csys == 0:
             result.append(xyz_basic)
-        # get input "coordinfo" [ cid type 0; location(1x3); T(3x3) ]:
-        if coordref is None:
-            coordref = {}
-        coordinfo = mkusetcoordinfo(csys, uset, coordref)
-        xyz_coord = coordinfo[1]
-        T = coordinfo[2:]  # transform to basic for coordinate system
-        g = T.T @ (xyz_basic - xyz_coord)
-        ctype = coordinfo[0, 1].astype(np.int64)
-        if ctype == 1:
-            result.append(g)
-        elif ctype == 2:
-            R = math.hypot(g[0], g[1])
-            theta = math.atan2(g[1], g[0])
-            result.append(np.array([R, theta * 180 / math.pi, g[2]]))
         else:
-            R = linalg.norm(g)
-            phi = math.atan2(g[1], g[0])
-            s = math.sin(phi)
-            c = math.cos(phi)
-            if abs(s) > abs(c):
-                theta = math.atan2(g[1] / s, g[2])
+            # get input "coordinfo" [ cid type 0; location(1x3); T(3x3) ]:
+            if coordref is None:
+                coordref = {}
+            coordinfo = mkusetcoordinfo(csys, uset, coordref)
+            xyz_coord = coordinfo[1]
+            T = coordinfo[2:]  # transform to basic for coordinate system
+            g = T.T @ (xyz_basic - xyz_coord)
+            ctype = coordinfo[0, 1].astype(np.int64)
+            if ctype == 1:
+                result.append(g)
+            elif ctype == 2:
+                R = math.hypot(g[0], g[1])
+                theta = math.atan2(g[1], g[0])
+                result.append(np.array([R, theta * 180 / math.pi, g[2]]))
             else:
-                theta = math.atan2(g[0] / c, g[2])
-            result.append(np.array([R, theta * 180 / math.pi, phi * 180 / math.pi]))
+                R = linalg.norm(g)
+                phi = math.atan2(g[1], g[0])
+                s = math.sin(phi)
+                c = math.cos(phi)
+                if abs(s) > abs(c):
+                    theta = math.atan2(g[1] / s, g[2])
+                else:
+                    theta = math.atan2(g[0] / c, g[2])
+                result.append(np.array([R, theta * 180 / math.pi, phi * 180 / math.pi]))
     if n_locations == 1:
         return result[0]
     else: 

--- a/pyyeti/nastran/n2p.py
+++ b/pyyeti/nastran/n2p.py
@@ -474,10 +474,10 @@ def replace_basic_cs(uset, new_cs_id, new_cs_in_basic=None):
     # 1. adjust all node locations:
     #           new_location_in_basic = T @ old_location + A
     A = new_cs_in_basic[0].reshape(3, 1)
-    xyz[::6] = (T @ xyz[::6].T + A).T
+    xyz[::6] = (T @ xyz[::6].T - A).T
 
     # 2. adjust all coord-system origins similarly:
-    xyz[2::6] = (T @ xyz[2::6].T + A).T
+    xyz[2::6] = (T @ xyz[2::6].T - A).T
 
     # 3. fix up all the ids ... 0 --> new_cs_id
     pv = current_cs_ids == 0


### PR DESCRIPTION
I believe these signs have the opposite the intended effect. If I define a new rectangular coordinate system, shifted 10 inches up in CORD2R format as
```
[10, 0, 0]
[10, 0, 1]
[11, 0, 0]
```
shouldn't all the x values be reduced by that amount? That would make the new uset values match the locations of those nodes in the new CS. For example if the original uset has a node at `[20, 1, 1]` the returned uset would then show it at `[10, 1, 1]`.

Perhaps I am misunderstanding how this function is intended to be used. I know the documentation in the header seems to confirm it currently works as intended. My goal was to get a uset in a new coordinate system, using the same definition for that coordinate system as in the bulk data. The current implementation seems more like "replace cs with basic," where `new_cs_in_basic=` is treated as the CS of the passed in uset, and the output uset is in basic.

If that's the intended functionality do you see any value in me copy-pasting this edit into a new function, something like `update_uset_cs(...)`, or is this a niche use case you don't see a need for? I'd defer to your judgment, if not I'll bring it in-house. 