### PR TITLE
Bulk wtinclude

### DIFF
--- a/docs/modules/nastran/bulk.rst
+++ b/docs/modules/nastran/bulk.rst
@@ -26,12 +26,14 @@ Limited set of read/write routines for Nastran bulk data
     rdtabled1
     rdwtbulk
     uset2bulk
+    wtassign
     wtextseout
     wtcoordcards
     wtcsuper
     wtdmig
     wtextrn
     wtgrids
+    wtinclude
     wtmpc
     wtnasints
     wtqcset

--- a/pyyeti/nastran/bulk.py
+++ b/pyyeti/nastran/bulk.py
@@ -64,7 +64,6 @@ __all__ = [
     "wtextseout",
     "mknast",
     "rddtipch",
-    "wrap_text_lines",
     "wtinclude",
     "wtassign",
 ]
@@ -4149,7 +4148,7 @@ def rddtipch(f, name="TUG1"):
     return iddof
 
 
-def wrap_text_lines(lines, max_length, separator):
+def _wrap_text_lines(lines, max_length, separator):
     """
     Combines the list of strings in lines into longer strings.  Each will be
     less than the specified maximum, and will be separated by the specified
@@ -4273,7 +4272,7 @@ def wtinclude(f, path, current_path=None, max_length=72):
     out_string = "INCLUDE '{}'\n".format(rel_path)
     if len(out_string) > max_length:
         lines = out_string.split("/")
-        out_string = "\n".join(wrap_text_lines(lines, max_length, "/"))
+        out_string = "\n".join(_wrap_text_lines(lines, max_length, "/"))
     f.write(out_string)
 
 
@@ -4299,7 +4298,7 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
         The path to the file.
     params : dict; optional
         Optional "describer" values to add to the assign statment.
-    current_path : string
+    current_path : string; optional
         The path to the directory where the Nastran input file is located.  If
         current_path is not specified, the output will use an absolute path.
     max_length : integer; optional
@@ -4326,15 +4325,17 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
            "output4": "OUTPUT4",
     }
     if assign_type not in cmd:
-        raise ValueError
-    if max_length < 24:
-        raise ValueError('max_length must be >24')
+        msg = ("invalid assign_type, must be one of 'input2', 'input4', 'output2', or "
+               "'output4', got '{}'")
+        raise ValueError(msg.format(assign_type))
+    if not max_length >= 24:
+        raise ValueError('max_length must be >=24')
     rel_path = _relative_path(path, current_path)
     # format path component
     # line wraps require a comma within the quoted path string
     line = "ASSIGN {} = '{}'".format(cmd[assign_type], rel_path)
     if len(line) > max_length:
-        lines = wrap_text_lines([line], max_length, ",")
+        lines = _wrap_text_lines([line], max_length, ",")
     else:
         lines = [line]
     # add params, with commas between each
@@ -4344,6 +4345,6 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
                 lines.append("{}".format(k.upper()))
             else:
                 lines.append("{}={}".format(k.upper(), v))
-    lines = wrap_text_lines(lines, max_length, ",")
+    lines = _wrap_text_lines(lines, max_length, ",")
     f.write("\n".join(lines))
     f.write("\n")

--- a/pyyeti/nastran/bulk.py
+++ b/pyyeti/nastran/bulk.py
@@ -4241,7 +4241,7 @@ def wtinclude(f, path, current_path=None, max_length=72):
 
     If possible, the relative path from current_path to path will be used.  The
     statment will be wrapped as needed such that no lines exceed the specified
-    col_length_limit.
+    max_length.
 
     Parameters
     ----------
@@ -4260,6 +4260,9 @@ def wtinclude(f, path, current_path=None, max_length=72):
 
     Notes
     -----
+    The max_length parameter must be at least 24 to allow space for the INCLUDE statement
+    on the first line.
+
     Forward slashes will always be used as path separators.  This ensures that
     relative paths will work on both Windows and Linux.
 
@@ -4271,6 +4274,8 @@ def wtinclude(f, path, current_path=None, max_length=72):
     >>> nastran.wtinclude(1, path, current_path)
     INCLUDE '../user1/model.blk'
     """
+    if not max_length >= 24:
+        raise ValueError("max_length must be >=24")
     rel_path = _relative_path(path, current_path)
     out_string = "INCLUDE '{}'\n".format(rel_path)
     if len(out_string) > max_length:
@@ -4286,7 +4291,7 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
 
     If possible, the relative path from current_path to path will be used.  The
     statment will be wrapped as needed such that no lines exceed the specified
-    col_length_limit.
+    max_length.
 
     Parameters
     ----------
@@ -4312,6 +4317,9 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
     -----
     The max_length parameter must be at least 24 to allow space for the ASSIGN statement
     and assign type on the first line.
+
+    Forward slashes will always be used as path separators.  This ensures that
+    relative paths will work on both Windows and Linux.
 
     Examples
     --------

--- a/pyyeti/nastran/bulk.py
+++ b/pyyeti/nastran/bulk.py
@@ -4279,6 +4279,11 @@ def wtinclude(f, path, current_path=None, max_length=72):
 
 def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72):
     """
+    Write a Nastran ASSIGN statement to a file.
+
+    If possible, the relative path from current_path to path will be used.  The
+    statment will be wrapped as needed such that no lines exceed the specified
+    col_length_limit.
 
     Parameters
     ----------
@@ -4291,18 +4296,29 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
         The type of ASSIGN statement.  This can be one of 'input2', 'input4',
         'output2', or 'output4'.
     path : string
-        The path to the file that will be included.
+        The path to the file.
     params : dict; optional
-        XXX
+        Optional "describer" values to add to the assign statment.
     current_path : string
-        XXX
+        The path to the directory where the Nastran input file is located.  If
+        current_path is not specified, the output will use an absolute path.
     max_length : integer; optional
-        The max length of each line of the include statment.
+        The max length of each line of the assign statment.
 
     Notes
     -----
     The max_length parameter must be at least 24 to allow space for the ASSIGN statement
-    itself on one line.
+    and assign type on the first line.
+
+    Examples
+    --------
+    >>> from pyyeti import nastran
+    >>> assign_type = 'output4'
+    >>> path = '/home/user1/out.op4'
+    >>> params = {'unit':101, 'delete':None}
+    >>> current_path = '/home/user2'
+    >>> nastran.wtassign(1, assign_type, path, params, current_path)
+    ASSIGN OUTPUT4 = '../user1/out.op4',UNIT=101,DELETE
     """
     cmd = {"input2": "INPUTT2",
            "input4": "INPUTT4",
@@ -4328,7 +4344,6 @@ def wtassign(f, assign_type, path, params=None, current_path=None, max_length=72
                 lines.append("{}".format(k.upper()))
             else:
                 lines.append("{}={}".format(k.upper(), v))
-    #breakpoint()
     lines = wrap_text_lines(lines, max_length, ",")
     f.write("\n".join(lines))
     f.write("\n")

--- a/tests/test_nastran.py
+++ b/tests/test_nastran.py
@@ -1470,6 +1470,12 @@ def test_relative_paths():
         assert output == expected
 
 
+def test_wtinclude_bad_input():
+    f = StringIO()
+    with pytest.raises(ValueError, match=r"max_length.*>=24"):
+        nastran.wtinclude(f, "bulk.bdf", max_length=20)
+
+
 def test_wtinclude():
     values = (
         ((r"c:\direc\bulk.bdf", r"c:\direc"), "INCLUDE 'bulk.bdf'\n"),
@@ -1515,7 +1521,7 @@ def test_wtassign_bad_input():
     with pytest.raises(ValueError, match=r"invalid assign_type.*'zzz'"):
         nastran.wtassign(f, "zzz", "output.op4")
     with pytest.raises(ValueError, match=r"max_length.*\>=24"):
-        nastran.wtassign(f, "input4", "output.op4", max_length=10)
+        nastran.wtassign(f, "input4", "output.op4", max_length=20)
 
 
 def test_wtassign():

--- a/tests/test_nastran.py
+++ b/tests/test_nastran.py
@@ -1406,3 +1406,122 @@ $$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$$
     assert (a == b).all()
     sbe = np.r_[5, 7, 16, 18, 27, 29, 9920001:9920021]
     assert (a == sbe).all()
+
+
+def test_wrap_text_lines_0line():
+    lines = []
+    output = nastran.wrap_text_lines(lines, 12, "/")
+    assert output == lines
+
+
+def test_wrap_text_lines_1line():
+    lines = ['abcdefghijkl']
+    output = nastran.wrap_text_lines(lines, 12, "/")
+    assert output == lines
+
+
+def test_wrap_text_lines_1line_too_long():
+    lines = ["abcdefghijkl"]
+    output = nastran.wrap_text_lines(lines, 10, "/")
+    assert output == ["abcdefghi", "jkl"]
+
+
+def test_wrap_text_lines_path1():
+    path = "/home/abcd/this/is/a/long/path/modes.op4"
+    lines = path.split("/")
+    output = nastran.wrap_text_lines(lines, 14, "/")
+    expected = ["/home/abcd/", "this/is/a/long",
+                "/path/", "modes.op4"]
+    assert output == expected
+
+
+def test_wrap_text_lines_path2():
+    path = "/home/abcd/this/is/a/long/path/modes.op4"
+    lines = path.split("/")
+    output = nastran.wrap_text_lines(lines, 15, "/")
+    expected = ["/home/abcd/this", "/is/a/long/path",
+                "/modes.op4"]
+    assert output == expected
+
+
+def test_wrap_text_lines_path3():
+    path = "/home/abcd/this/is/a/long/path/modes.op4"
+    lines = path.split("/")
+    output = nastran.wrap_text_lines(lines, 20, "/")
+    expected = ["/home/abcd/this/is/a", "/long/path/modes.op4"]
+    assert output == expected
+
+
+def test_wtinclude_path1():
+    path = r"c:\direc\bulk.bdf"
+    current_path = r"c:\direc"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_path1_diffcap():
+    path = r"d:\direc\bulk.bdf"
+    current_path = r"D:\direc"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_path2():
+    path = r"c:\direc\bulk.bdf"
+    current_path = r"c:\\"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'direc/bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_path3():
+    path = r"c:\direc1\direc2\bulk.bdf"
+    current_path = r"c:\direc1\direc3"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE '../direc2/bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_path4():
+    path = (r"c:\direc1\direc2\direc3\direc4\direc5\direc6\direc7\direc8\direc9"
+            r"\direc10\direc11\bulk.bdf")
+    current_path = r"c:\\"
+    output = nastran.wtinclude(path, current_path)
+    expected = ("INCLUDE 'direc1/direc2/direc3/direc4/direc5/direc6/direc7/"
+                "direc8/direc9/\n"
+                "direc10/direc11/bulk.bdf'\n")
+    assert output == expected
+
+
+def test_wtinclude_path5():
+    path = "/direc1/direc2/bulk3.bdf"
+    current_path = "/direc1"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'direc2/bulk3.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_abspath1():
+    path = r"c:\direc1\direc2\bulk.bdf"
+    current_path = None
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'c:/direc1/direc2/bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_abspath2():
+    path = r"/direc1/direc2/bulk.bdf"
+    current_path = None
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE '/direc1/direc2/bulk.bdf'\n"
+    assert output == expected
+
+
+def test_wtinclude_different_drive_letters():
+    path = r"c:\direc1\bulk.bdf"
+    current_path = r"d:\direc1"
+    output = nastran.wtinclude(path, current_path)
+    expected = "INCLUDE 'c:/direc1/bulk.bdf'\n"
+    assert output == expected


### PR DESCRIPTION
Added two functions to pyyeti.nastran.bulk
- wtinclude: write an INCLUDE statement
- wtassign: write an ASSIGN statement

This ended up being more complicated than I expected.  I wanted it to split lines on path separators if possible, but still produce valid output if a path segment was too long for that to be possible.  If you eliminate that requirement it could probably be done with textwrap instead of _wrap_text_lines, but the output would be harder to read.