### PR TITLE
Fix test warnings

### DIFF
--- a/pyyeti/cyclecount.py
+++ b/pyyeti/cyclecount.py
@@ -427,7 +427,7 @@ def getbins(bins, mx, mn, right=True, check_bounds=False):
         # raise ValueError("`mx` and `mn` must not be equal")
 
     if bins.size == 1:
-        bins = int(bins)
+        bins = int(bins[0])
         bb = np.linspace(mn, mx, bins + 1)
         p = 0.001 * (mx - mn)
         if right:

--- a/pyyeti/locate.py
+++ b/pyyeti/locate.py
@@ -303,7 +303,7 @@ def mat_intersect(D1, D2, keep=0):
         switch = True
 
     # to use the byte-string view, types must be the same:
-    out_dtype = np.find_common_type([haystack.dtype, needles.dtype], [])
+    out_dtype = np.result_type(haystack.dtype, needles.dtype)
 
     # view entire rows as a single values:
     haystack = _bytes_view(haystack, out_dtype).ravel()

--- a/pyyeti/nastran/bulk.py
+++ b/pyyeti/nastran/bulk.py
@@ -1224,9 +1224,9 @@ def rddmig(
                     val.dtype = dtype
                     j += ints_per_number
                     ri = np.searchsorted(r_id_dof, nid * 10 + dof)
-                    mat[ri, ci] = val
+                    mat[ri, ci] = val[0]
                     if form == 6:
-                        mat[ci, ri] = val
+                        mat[ci, ri] = val[0]
                     nid = rec[j]
                 j += 2
             dct[name] = pd.DataFrame(mat, index=rowindex, columns=colindex)

--- a/pyyeti/nastran/op2.py
+++ b/pyyeti/nastran/op2.py
@@ -1249,7 +1249,7 @@ class OP2:
                 nmodes = (endpos - startpos) // bytes_per_mode
                 keep = lam
                 lam = np.empty(nmodes, float)
-                lam[0] = keep
+                lam[0] = keep[0]
                 keep = ougv1
                 ougv1 = np.empty((keep.shape[0], nmodes), float, order="F")
                 ougv1[:, 0] = keep[:, 0]

--- a/pyyeti/tests/test_cb.py
+++ b/pyyeti/tests/test_cb.py
@@ -694,7 +694,8 @@ def test_cbcoordchk():
     assert abs(chk0.maxerr).max() < 1e-5
 
     # a case where the refpoint_chk should be 'fail':
-    chk2 = cb.cbcoordchk(kaa, b, [25, 26, 27, 31, 32, 33], verbose=False)
+    with pytest.warns(la.LinAlgWarning, match=r"Ill\-conditioned matrix"):
+        chk2 = cb.cbcoordchk(kaa, b, [25, 26, 27, 31, 32, 33], verbose=False)
     assert chk2.refpoint_chk == "fail"
 
 
@@ -1044,7 +1045,8 @@ def test_cbcoordchk3():
     assert abs(chk0.maxerr).max() < 1e-5
 
     # a case where the refpoint_chk should be 'fail':
-    chk2 = cb.cbcoordchk(kaa, b, [25, 26, 27, 31, 32, 33], verbose=False)
+    with pytest.warns(la.LinAlgWarning, match=r"Ill\-conditioned matrix"):
+        chk2 = cb.cbcoordchk(kaa, b, [25, 26, 27, 31, 32, 33], verbose=False)
     assert chk2.refpoint_chk == "fail"
 
 

--- a/pyyeti/tests/test_cla.py
+++ b/pyyeti/tests/test_cla.py
@@ -695,7 +695,8 @@ def owlab(pth):
             print("Running {} case {}".format(event, j + 1))
             F = interp.interp1d(ff[:, 0], ff[:, 1:].T, axis=1, fill_value=0.0)(freq)
             results.solvepsd(nas, caseid, DR, fs, F, T, freq)
-            results.psd_data_recovery(caseid, DR, len(rnd), j, verbose=3)
+            with pytest.warns(RuntimeWarning, match=r"Integ.*freq.*inacc.*result"):
+                results.psd_data_recovery(caseid, DR, len(rnd), j, verbose=3)
 
         # save results:
         cla.save("results.pgz", results)
@@ -726,7 +727,8 @@ def owlab(pth):
                 verbose = not verbose
                 freq2 = +freq2  # make copy
                 freq2[-1] = 49.7  # to cause error on next 'solvepsd'
-                results2.psd_data_recovery(caseid, DR, len(rnd), j, resp_time=20)
+                with pytest.warns(RuntimeWarning, match=r"Integ.*freq.*inacc.*result"):
+                    results2.psd_data_recovery(caseid, DR, len(rnd), j, resp_time=20)
             else:
                 with pytest.raises(ValueError):
                     results2.solvepsd(

--- a/pyyeti/tests/test_cla.py
+++ b/pyyeti/tests/test_cla.py
@@ -919,20 +919,18 @@ def compare(pth):
         results["extreme"]["ifa2"] = results["extreme"]["net_ifatm"]
 
         plt.close("all")
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        regex = re.compile(r"Some comp.*skipped.*ifa2", re.DOTALL)
+        with pytest.warns(RuntimeWarning, match=regex):
             results["extreme"].rptpct(lvc, names=("LSP", "Contractor"))
-            assert issubclass(w[-1].category, RuntimeWarning)
-            assert "Some comparisons" in str(w[-1].message)
-            assert "ifa2" in str(w[-1].message)
 
         plt.close("all")
         # modify lvc['cglf'] for testing:
         lvc["cglf"].ext[0, 0] = 0.57  # cause a -7.3% diff
         lvc["cglf"].ext[5, 0] = 0.449  # cause a 17.7% diff
-        results["extreme"].rptpct(
-            lvc, names=("LSP", "Contractor"), direc="absmax_compare", doabsmax=True
-        )
+        with pytest.warns(RuntimeWarning, match=r"Some compar.*skipped"):
+            results["extreme"].rptpct(
+                lvc, names=("LSP", "Contractor"), direc="absmax_compare", doabsmax=True
+            )
 
         plt.close("all")
         results["extreme"].rptpct(

--- a/pyyeti/tests/test_era.py
+++ b/pyyeti/tests/test_era.py
@@ -63,7 +63,7 @@ def test_era():
             # show_plot=False,
             verbose=False,
         )
-        verify_one_match(records, [r"Matplotlib.*using agg", r"figure layout.*tight"])
+        verify_one_match(records, [r"Matplotlib.*using agg"])
     assert np.allclose(era_fit.freqs_hz, freq_hz)
     assert np.allclose(era_fit.zeta, zeta)
     phi_rat = phi / era_fit.phi

--- a/pyyeti/tests/test_nastran.py
+++ b/pyyeti/tests/test_nastran.py
@@ -2,6 +2,7 @@ import math
 import numpy as np
 import os
 import tempfile
+import warnings
 from io import StringIO
 from pathlib import Path
 import matplotlib.pyplot as plt
@@ -1532,7 +1533,8 @@ def test_wtrspline_rings():
         rsplines1 = nastran.rdcards(f, "RSPLINE")
 
     with StringIO() as f:
-        with pytest.warns(UserWarning, match=r"figure layout.*changed.*tight"):
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
             nastran.wtrspline_rings(
                 f, uset1, uset2, 1001, 2001, makeplot=ax, independent="n amE 2"
             )

--- a/pyyeti/tests/test_nastran.py
+++ b/pyyeti/tests/test_nastran.py
@@ -1532,9 +1532,10 @@ def test_wtrspline_rings():
         rsplines1 = nastran.rdcards(f, "RSPLINE")
 
     with StringIO() as f:
-        nastran.wtrspline_rings(
-            f, uset1, uset2, 1001, 2001, makeplot=ax, independent="n amE 2"
-        )
+        with pytest.warns(UserWarning, match=r"figure layout.*changed.*tight"):
+            nastran.wtrspline_rings(
+                f, uset1, uset2, 1001, 2001, makeplot=ax, independent="n amE 2"
+            )
         u2, c2 = nastran.bulk2uset(f)
         rsplines2 = nastran.rdcards(f, "RSPLINE")
 

--- a/pyyeti/tests/test_op2.py
+++ b/pyyeti/tests/test_op2.py
@@ -1,5 +1,6 @@
 import math
 import os
+import re
 import tempfile
 import numpy as np
 import pandas as pd
@@ -475,7 +476,11 @@ def test_rdpostop2():
 
 
 def test_rdpostop2_assemble():
-    post = op2.rdpostop2("pyyeti/tests/nas2cam_extseout/assemble.op2", 1, 1)
+    with pytest.warns(RuntimeWarning) as record:
+        post = op2.rdpostop2("pyyeti/tests/nas2cam_extseout/assemble.op2", 1, 1)
+        assert len(record) >= 2
+        assert re.search(r"ACODE.*52.*not accept", record[0].message.args[0])
+        assert re.search(r"TCODE.*1001.*not accept", record[1].message.args[0])
     assert np.all(post["selist"] == [[101, 0], [102, 0], [0, 0]])
     sebulk = np.array(
         [[101, 5, -1, 2, 0.0, 1, 3, 101], [102, 5, -1, 2, 0.0, 1, 3, 102]]

--- a/pyyeti/tests/test_op2.py
+++ b/pyyeti/tests/test_op2.py
@@ -475,12 +475,23 @@ def test_rdpostop2():
     assert np.all(oug["lambda"] == lam)
 
 
+def verify_one_match(records, regexes):
+    """Verify that at least one warning matches each regex."""
+    for regex in regexes:
+        match_found = False
+        for record in records:
+            match_found = (
+                re.search(regex, record.message.args[0]) is not None or match_found
+            )
+        assert match_found, f"No matching warning found: {regex}"
+
+
 def test_rdpostop2_assemble():
-    with pytest.warns(RuntimeWarning) as record:
+    with pytest.warns(RuntimeWarning) as records:
         post = op2.rdpostop2("pyyeti/tests/nas2cam_extseout/assemble.op2", 1, 1)
-        assert len(record) >= 2
-        assert re.search(r"ACODE.*52.*not accept", record[0].message.args[0])
-        assert re.search(r"TCODE.*1001.*not accept", record[1].message.args[0])
+        verify_one_match(
+            records, [r"ACODE.*52.*not accept", r"TCODE.*1001.*not accept"]
+        )
     assert np.all(post["selist"] == [[101, 0], [102, 0], [0, 0]])
     sebulk = np.array(
         [[101, 5, -1, 2, 0.0, 1, 3, 101], [102, 5, -1, 2, 0.0, 1, 3, 102]]

--- a/pyyeti/tests/test_stats.py
+++ b/pyyeti/tests/test_stats.py
@@ -4,11 +4,12 @@ import pytest
 
 
 def test_ksingle():
-    v = stats.ksingle(
-        [0.95, 0.96, 0.97, 0.98, 0.99],
-        [[0.50], [0.75], [0.90], [0.95]],
-        [[[2]], [[5]], [[10500]]],
-    )
+    with pytest.warns(RuntimeWarning, match=r"divide by zero.*_nct_ppf"):
+        v = stats.ksingle(
+            [0.95, 0.96, 0.97, 0.98, 0.99],
+            [[0.50], [0.75], [0.90], [0.95]],
+            [[[2]], [[5]], [[10500]]],
+        )
     # answers from CAM:
     s = np.array(
         [


### PR DESCRIPTION
I fixed a number of warnings that were output from the tests.

There were two types of changes to the actual code

1. Assigning `a[0] = b` where `b` is an array with shape (1, ).  This is deprecated in NumPy 1.25 and will be an error in the future.  I replaced it with `a[0] = b[0]`.
2. The `numpy.find_common_types` function is also deprecated in NumPy 1.25.  I replaced it with `numpy.result_type`.  I think this meets the intent.

The other changes just catch warnings so they are verified and aren't displayed when running the tests.  I made one change per commit so you can review them easily.