### PR TITLE
Add requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+numpy
+scipy
+matplotlib
+pandas 
+xlsxwriter
+h5py
+packaging


### PR DESCRIPTION
We use poetry for dependency management, and are having issues with it not correctly discovering PyYeti's dependencies.

This is a quick fix.  Longer term, it would be interesting to move this into pyproject.toml which seems to be the new way for defining dependencies.  I'm just not sure how to do it in a way that doesn't conflict with your current packaging method.