### PR TITLE
No warning at import if numba is installed, seems unnecessary.

### DIFF
--- a/pyyeti/cyclecount.py
+++ b/pyyeti/cyclecount.py
@@ -20,12 +20,13 @@ else:
 try:
     import pyyeti.rainflow.c_rain as rain
 except ImportError:
-    warnings.warn(
-        "Compiled C version of rainflow algorithm failed to "
-        "import. Using plain Python version, which can be very "
-        "slow if 'numba' is not installed.",
-        RuntimeWarning,
-    )
+    if not HAVE_NUMBA:
+        warnings.warn(
+            "Compiled C version of rainflow algorithm failed to "
+            "import. Using plain Python version, which can be very "
+            "slow if 'numba' is not installed.",
+            RuntimeWarning,
+        )
     import pyyeti.rainflow.py_rain as rain
 
 # FIXME: We need the str/repr formatting used in Numpy < 1.14.


### PR DESCRIPTION
This warnings is issued at pyyeti import if you don't have the compiled C rainflow algorithm, even if you have numba installed. Seems unnecessary to me to show this warning if numba is installed.