### PR TITLE
Set numba lower bound to avoid weird version combinations with numpy

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
     "pandas",
     "xlsxwriter",
     "h5py",
-    "numba",
+    "numba>=0.54",
 ]
 
 classifiers = [


### PR DESCRIPTION
### tl;dr
This PR prevents install errors for packages with dependencies like
```
    "numpy>=1.26",
    "pyyeti",
```

### More background
I have a package with the dependencies above. Trying to install it with [uv](https://docs.astral.sh/uv/) fails. What I think is happening is that uv prioritizes the latest version of numpy (2.3.1) because numpy is a direct dependency. numba is an indirect dependency via pyyeti, and the latest version (0.61.2) is not compatible since it requires numpy<2.3. In fact it seems numba has set an upper bound on numpy since numba 0.54.0. uv resolves this by choosing numba 0.53.1 which does not set an upper bound on numpy. However, numba 0.53.1 fails to build because it is only supported on Python >=3.6,<3.10.

I can fix this by setting an upper bound on numpy in my package (`numpy>=1.26,<2.3`). But I also think it is a good idea to be more strict on the dependency here in pyyeti to avoid issues like this for other packages depending on pyyeti (it took me _quiet a while_ to figure out what the problem actually was).

There shouldn't be any pyyeti users who need numba 0.53.1 or earlier since it came out before Python 3.10 which pyyeti requires.
