### PR TITLE
Update the Methodology to Find delta-t When Resampling a Signal

### DIFF
--- a/pyyeti/dsp.py
+++ b/pyyeti/dsp.py
@@ -276,7 +276,7 @@ def resample(data, p, q, *, axis=-1, beta=14, pts=10, t=None, getfir=False):
         if getfir:
             return RData, fir
         return RData
-    tnew = np.arange(n) * (t[1] - t[0]) * ln / n + t[0]
+    tnew = np.arange(n) * np.mean(np.diff(t)) * ln / n + t[0]
     if getfir:
         return RData, tnew, fir
     return RData, tnew


### PR DESCRIPTION
Hi Tim,

This is a minor change that will improve the robustness of the resample function to work with signals that are not perfectly uniform in their time-steps. In the existing code, if `t[1] - t[0]` is not representative of the "intended" time step of the signal, the returned time vector will not end at `t[-1]`. I am running into issues with real-world data where the resampled vector can be dramatically different. A 20 second signal can be reduced to a fraction of a second, or vice versa. By updating the code to use the mean of the time steps, these cases end at `t[-1]`. 